### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "url":"https://github.com/nomocas/autobahn.git"
   },
   "dependencies": {
-    "deepjs":">=0.9.9"
+    "deepjs":">=0.9.9",
+    "promised-io": "0.3.0",
+    "sanitizer": "0.0.15",
+    "formidable": "1.0.11",
+    "imagemagick": "0.1.3"
   }
 }


### PR DESCRIPTION
Les dépendances pour Autobahn 0.2 devraient être mentionnées dans son package.json.
Attention de ne pas merge ça dans le master pour éviter de mettre le boxon.
